### PR TITLE
Fix telescope's mapping error

### DIFF
--- a/lua/stickybuf/config.lua
+++ b/lua/stickybuf/config.lua
@@ -25,6 +25,7 @@ local Config = {
   filetype = {
     aerial = "filetype",
     nerdtree = "filetype",
+    TelescopePrompt = "filetype",
   },
   bufname = {
     ["Neogit.*Popup"] = "bufnr",


### PR DESCRIPTION
I additionally found that the error occurs when I get to the latest telescope.

```lua
E5108: Error executing lua ...ack/packer/opt/telescope.nvim/lua/telescope/mappings.lua:240: Unsure of how we got this failure: 6 8
stack traceback:
        [C]: in function 'assert'
        ...ack/packer/opt/telescope.nvim/lua/telescope/mappings.lua:240: in function 'execute_keymap'
        [string ":lua"]:1: in main chunk
```
`TelescopePrompt` should be disabled by default.