### PR TITLE
fix BufUnload-related neogit commit issue

### DIFF
--- a/lua/stickybuf.lua
+++ b/lua/stickybuf.lua
@@ -285,7 +285,12 @@ M.should_auto_pin = function(bufnr)
   elseif filetype == "fern" and (vim.wo.winfixwidth or vim.wo.winfixheight) then
     -- Only pin fern if it was opened as a split (has fixed height/width)
     return "filetype"
-  elseif vim.startswith(filetype, "Neogit") then
+  elseif
+    vim.startswith(filetype, "Neogit")
+    -- NeogitCommitMessage relies on BufUnload, can't apply to it
+    -- https://github.com/NeogitOrg/neogit/blob/51a6e6c8952b361300be57b36c8e1b973880cdd7/lua/neogit/buffers/commit_editor/init.lua#L43
+    and filetype ~= "NeogitCommitMessage"
+  then
     if vim.fn.winnr("$") > 1 then
       return "filetype"
     end


### PR DESCRIPTION
turns out the neogit commit message mechanism relies on BufUnload.
The outcome was that a neogit window appears where you can enter the commit message.. You enter the message, :wq, the commit is committed, the window closes then reopens immediately. The issue is fixed when asking stickybuf to ignore the NeogitCommitMessage file type.

In my commit I wrote it's related to neogit relying on BufUnload, although i'm not 100% sure of the exact sequence of events and cause of the issue.